### PR TITLE
Add easy-access properties to the Stripe class

### DIFF
--- a/src/Stripe/Stripe.php
+++ b/src/Stripe/Stripe.php
@@ -14,6 +14,14 @@ use Stripe\Api\Customers;
 use Stripe\Api\Plans;
 use Stripe\Api\Subscriptions;
 
+/**
+ * Class Stripe
+ *
+ * @property Api\Cards $cards
+ * @property Api\Customers $customers
+ * @property Api\Plans $plans
+ * @property Api\Subscriptions $subscriptions
+ */
 class Stripe {
     /**
      * @var Client
@@ -31,6 +39,23 @@ class Stripe {
     public function __construct($apiKey){
         $this->client = new Client($apiKey);
     }
+
+	/**
+	 * Convenience function for accessing cards, customers, plans and subscriptions
+	 *
+	 * @param $name
+	 * @return mixed
+	 */
+	public function __get($name)
+	{
+		$allowed = array('cards', 'customers', 'plans', 'subscriptions');
+
+		if (in_array($name, $allowed)){
+			return $this->{$name}();
+		}
+
+		throw new \UnexpectedValueException(sprintf('Invalid property: %s', $name));
+	}
 
     /**
      * @return Client


### PR DESCRIPTION
This PR provides property access for Cards, Customers, Plans and Subscriptions on the Stripe class.

``` php
$stripe = new \Stripe\Stripe;
$customers = $stripe->customers;
```
