### PR TITLE
Add Accounts

### DIFF
--- a/src/Stripe/Api/Accounts.php
+++ b/src/Stripe/Api/Accounts.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * User: Don Gilbert
+ * Date: 3/27/2014
+ * Time: 4:50 PM
+ */
+
+namespace Stripe\Api;
+
+use Stripe\Response\Accounts\AccountResponse;
+
+class Accounts extends AbstractApi
+{
+    const ACCOUNT_RESPONSE_CLASS = 'Stripe\Response\Accounts\AccountResponse';
+
+    /**
+     * @return AccountResponse
+     * @link https://stripe.com/docs/api/curl#retrieve_account
+     */
+    public function getAccount()
+    {
+        return $this->client->request('GET', 'account', self::ACCOUNT_RESPONSE_CLASS);
+    }
+}

--- a/src/Stripe/Response/Accounts/AccountResponse.php
+++ b/src/Stripe/Response/Accounts/AccountResponse.php
@@ -1,0 +1,301 @@
+<?php
+/**
+ * User: Don Gilbert
+ * Date: 3/27/2014
+ * Time: 4:50 PM
+ */
+
+namespace Stripe\Response\Accounts;
+
+use JMS\Serializer\Annotation\Type;
+
+class AccountResponse
+{
+    /**
+     * @Type("string")
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * @Type("string")
+     * @var string
+     */
+    protected $email;
+
+    /**
+     * @Type("string")
+     * @var string
+     */
+    protected $statementDescriptor;
+
+    /**
+     * @Type("string")
+     * @var string
+     */
+    protected $displayName;
+
+    /**
+     * @Type("string")
+     * @var string
+     */
+    protected $timezone;
+
+    /**
+     * @Type("boolean")
+     * @var bool
+     */
+    protected $detailsSubmitted;
+
+    /**
+     * @Type("boolean")
+     * @var bool
+     */
+    protected $chargeEnabled;
+
+    /**
+     * @Type("boolean")
+     * @var bool
+     */
+    protected $transferEnabled;
+
+    /**
+     * @Type("array")
+     * @var array
+     */
+    protected $currenciesSupported;
+
+    /**
+     * @Type("string")
+     * @var string
+     */
+    protected $defaultCurrency;
+
+    /**
+     * @Type("string")
+     * @var string
+     */
+    protected $country;
+
+    /**
+     * @Type("string")
+     * @var string
+     */
+    protected $object;
+
+    /**
+     * @param boolean $chargeEnabled
+     * @return $this
+     */
+    public function setChargeEnabled($chargeEnabled)
+    {
+        $this->chargeEnabled = $chargeEnabled;
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getChargeEnabled()
+    {
+        return $this->chargeEnabled;
+    }
+
+    /**
+     * @param string $country
+     * @return $this
+     */
+    public function setCountry($country)
+    {
+        $this->country = $country;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCountry()
+    {
+        return $this->country;
+    }
+
+    /**
+     * @param array $currenciesSupported
+     * @return $this
+     */
+    public function setCurrenciesSupported($currenciesSupported)
+    {
+        $this->currenciesSupported = $currenciesSupported;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCurrenciesSupported()
+    {
+        return $this->currenciesSupported;
+    }
+
+    /**
+     * @param string $defaultCurrency
+     * @return $this
+     */
+    public function setDefaultCurrency($defaultCurrency)
+    {
+        $this->defaultCurrency = $defaultCurrency;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDefaultCurrency()
+    {
+        return $this->defaultCurrency;
+    }
+
+    /**
+     * @param boolean $detailsSubmitted
+     * @return $this
+     */
+    public function setDetailsSubmitted($detailsSubmitted)
+    {
+        $this->detailsSubmitted = $detailsSubmitted;
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getDetailsSubmitted()
+    {
+        return $this->detailsSubmitted;
+    }
+
+    /**
+     * @param string $displayName
+     * @return $this
+     */
+    public function setDisplayName($displayName)
+    {
+        $this->displayName = $displayName;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDisplayName()
+    {
+        return $this->displayName;
+    }
+
+    /**
+     * @param string $email
+     * @return $this
+     */
+    public function setEmail($email)
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * @param string $id
+     * @return $this
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param string $object
+     * @return $this
+     */
+    public function setObject($object)
+    {
+        $this->object = $object;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getObject()
+    {
+        return $this->object;
+    }
+
+    /**
+     * @param string $statementDescriptor
+     * @return $this
+     */
+    public function setStatementDescriptor($statementDescriptor)
+    {
+        $this->statementDescriptor = $statementDescriptor;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStatementDescriptor()
+    {
+        return $this->statementDescriptor;
+    }
+
+    /**
+     * @param string $timezone
+     * @return $this
+     */
+    public function setTimezone($timezone)
+    {
+        $this->timezone = $timezone;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTimezone()
+    {
+        return $this->timezone;
+    }
+
+    /**
+     * @param boolean $transferEnabled
+     * @return $this
+     */
+    public function setTransferEnabled($transferEnabled)
+    {
+        $this->transferEnabled = $transferEnabled;
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getTransferEnabled()
+    {
+        return $this->transferEnabled;
+    }
+}

--- a/src/Stripe/Stripe.php
+++ b/src/Stripe/Stripe.php
@@ -9,6 +9,7 @@ namespace Stripe;
 
 
 use Stripe\Api\AbstractApi;
+use Stripe\Api\Accounts;
 use Stripe\Api\Cards;
 use Stripe\Api\Charges;
 use Stripe\Api\Customers;
@@ -19,7 +20,9 @@ use Stripe\Api\Subscriptions;
 /**
  * Class Stripe
  *
+ * @property Api\Accounts
  * @property Api\Cards $cards
+ * @property Api\Charges $charges
  * @property Api\Customers $customers
  * @property Api\Invoices $invoices
  * @property Api\Plans $plans
@@ -46,7 +49,7 @@ class Stripe
     }
 
     /**
-     * Convenience method for accessing non-existant but available properties
+     * Convenience method for accessing non-existent but available properties
      *
      * @param $name
      * @throws \UnexpectedValueException
@@ -55,7 +58,7 @@ class Stripe
     public function __get($name)
     {
         $allowed = array(
-            'cards', 'charges', 'customers',
+            'accounts', 'cards', 'charges', 'customers',
             'invoices', 'plans', 'subscriptions'
         );
 
@@ -72,6 +75,14 @@ class Stripe
     public function getClient()
     {
         return $this->client;
+    }
+
+    /**
+     * @return Accounts
+     */
+    public function accounts()
+    {
+        return $this->getApi('Accounts');
     }
 
     /**

--- a/tests/Stripe/Tests/Api/AccountsTest.php
+++ b/tests/Stripe/Tests/Api/AccountsTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * User: Don Gilbert
+ * Date: 3/27/2014
+ * Time: 4:50 PM
+ */
+
+namespace Stripe\Tests\Api;
+
+
+use Stripe\Api\Accounts;
+use Stripe\Tests\StripeTestCase;
+
+class CardsTest extends StripeTestCase
+{
+    /**
+     * @var Accounts
+     */
+    protected $accounts;
+
+    /**
+     * @var string
+     */
+    protected $customerId;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->accounts = new Accounts($this->client);
+    }
+
+    public function testGetAccount()
+    {
+        $account = $this->accounts->getAccount();
+        $this->assertInstanceOf(Accounts::ACCOUNT_RESPONSE_CLASS, $account);
+    }
+}


### PR DESCRIPTION
Implements the (very simple) accounts part of the API.

One of the items returned in this call are the supported currencies in the account. I wonder if this could actually prove useful in the create Invoice Item call, since it's required to pass a valid currency - https://stripe.com/docs/api/curl#create_invoiceitem
