### PR TITLE
Standardize Requests

### DIFF
--- a/src/Stripe/Api/Accounts.php
+++ b/src/Stripe/Api/Accounts.php
@@ -19,6 +19,6 @@ class Accounts extends AbstractApi
      */
     public function getAccount()
     {
-        return $this->client->request('GET', 'account', self::ACCOUNT_RESPONSE_CLASS);
+        return $this->client->get('account', self::ACCOUNT_RESPONSE_CLASS);
     }
 }

--- a/src/Stripe/Api/Cards.php
+++ b/src/Stripe/Api/Cards.php
@@ -32,7 +32,7 @@ class Cards extends AbstractApi
     public function createCardFromToken($customerId, $token)
     {
         try {
-            $response = $this->client->request('POST', $this->buildUrl($customerId), 'Stripe\Response\Cards\CardResponse', array('card' => $token));
+            $response = $this->client->post($this->buildUrl($customerId), 'Stripe\Response\Cards\CardResponse', array('card' => $token));
         } catch (StripeException $e) {
             throw $this->handleError($e);
         }
@@ -50,7 +50,7 @@ class Cards extends AbstractApi
     public function createCard($customerId, CreateCardRequest $request)
     {
         try {
-            $response = $this->client->request('POST', $this->buildUrl($customerId), 'Stripe\Response\Cards\CardResponse', array('card' => $request));
+            $response = $this->client->post($this->buildUrl($customerId), 'Stripe\Response\Cards\CardResponse', array('card' => $request));
         } catch (StripeException $e) {
             throw $this->handleError($e);
         }
@@ -68,7 +68,7 @@ class Cards extends AbstractApi
     public function updateCard($customerId, $cardId, UpdateCardRequest $request)
     {
         try {
-            $response = $this->client->request('POST', $this->buildUrl($customerId, $cardId), 'Stripe\Response\Cards\CardResponse', $request);
+            $response = $this->client->post($this->buildUrl($customerId, $cardId), 'Stripe\Response\Cards\CardResponse', $request);
         } catch (StripeException $e) {
             throw $this->handleError($e);
         }
@@ -83,7 +83,7 @@ class Cards extends AbstractApi
      */
     public function getCard($customerId, $cardId)
     {
-        return $this->client->request('GET', $this->buildUrl($customerId, $cardId), 'Stripe\Response\Cards\CardResponse');
+        return $this->client->get($this->buildUrl($customerId, $cardId), 'Stripe\Response\Cards\CardResponse');
     }
 
     /**
@@ -93,7 +93,7 @@ class Cards extends AbstractApi
      */
     public function deleteCard($customerId, $cardId)
     {
-        return $this->client->request('DELETE', $this->buildUrl($customerId, $cardId), 'Stripe\Response\DeleteResponse');
+        return $this->client->delete($this->buildUrl($customerId, $cardId), 'Stripe\Response\DeleteResponse');
     }
 
     /**
@@ -105,7 +105,7 @@ class Cards extends AbstractApi
      */
     public function listCards($customerId, $count = 10, $offset = 0)
     {
-        return $this->client->request('GET', $this->buildUrl($customerId), 'Stripe\Response\Cards\ListCardsResponse', null, array('count' => $count, 'offset' => $offset));
+        return $this->client->get($this->buildUrl($customerId), 'Stripe\Response\Cards\ListCardsResponse', null, array('count' => $count, 'offset' => $offset));
     }
 
     /**
@@ -166,4 +166,4 @@ class Cards extends AbstractApi
         }
         return $e;
     }
-} 
+}

--- a/src/Stripe/Api/Invoices.php
+++ b/src/Stripe/Api/Invoices.php
@@ -24,7 +24,7 @@ class Invoices extends AbstractApi
      */
     public function createInvoice(CreateInvoiceRequest $request)
     {
-        return $this->client->request('POST', 'invoices', self::INVOICE_RESPONSE_CLASS, $request);
+        return $this->client->post('invoices', self::INVOICE_RESPONSE_CLASS, $request);
     }
 
     /**
@@ -34,7 +34,7 @@ class Invoices extends AbstractApi
      */
     public function getInvoice($invoiceId)
     {
-        return $this->client->request('GET', 'invoices/' . $invoiceId, self::INVOICE_RESPONSE_CLASS);
+        return $this->client->get('invoices/' . $invoiceId, self::INVOICE_RESPONSE_CLASS);
     }
 
     /**
@@ -61,7 +61,7 @@ class Invoices extends AbstractApi
         if (!is_null($metadata)) {
             $data['metadata'] = $metadata;
         }
-        return $this->client->request('POST', 'invoices/' . $invoiceId, self::INVOICE_RESPONSE_CLASS, $data);
+        return $this->client->post('invoices/' . $invoiceId, self::INVOICE_RESPONSE_CLASS, $data);
     }
 
     /**
@@ -71,7 +71,7 @@ class Invoices extends AbstractApi
      */
     public function payInvoice($invoiceId)
     {
-        return $this->client->request('POST', 'invoices/' . $invoiceId . '/pay', self::INVOICE_RESPONSE_CLASS);
+        return $this->client->post('invoices/' . $invoiceId . '/pay', self::INVOICE_RESPONSE_CLASS);
     }
 
     /**
@@ -82,7 +82,7 @@ class Invoices extends AbstractApi
      */
     public function listInvoices($count = 10, $offset = 0)
     {
-        return $this->client->request('GET', 'invoices', 'Stripe\Response\Invoices\ListInvoicesResponse', null, array('count' => $count, 'offset' => $offset));
+        return $this->client->get('invoices', 'Stripe\Response\Invoices\ListInvoicesResponse', null, array('count' => $count, 'offset' => $offset));
     }
 
     /**
@@ -95,7 +95,7 @@ class Invoices extends AbstractApi
      */
     public function listInvoiceLineItems($invoiceId, $count = 10, $offset = 0)
     {
-        return $this->client->request('GET', 'invoices/' . $invoiceId . '/lines', 'Stripe\Response\Invoices\ListLineItemsResponse', null, array('count' => $count, 'offset' => $offset));
+        return $this->client->get('invoices/' . $invoiceId . '/lines', 'Stripe\Response\Invoices\ListLineItemsResponse', null, array('count' => $count, 'offset' => $offset));
     }
 
     /**
@@ -110,7 +110,7 @@ class Invoices extends AbstractApi
         if (!is_null($subscription)) {
             $data['subscription'] = $subscription;
         }
-        return $this->client->request('GET', 'invoices/upcoming', self::INVOICE_RESPONSE_CLASS, null, $data);
+        return $this->client->get('invoices/upcoming', self::INVOICE_RESPONSE_CLASS, null, $data);
     }
 
     /**

--- a/src/Stripe/Api/Plans.php
+++ b/src/Stripe/Api/Plans.php
@@ -24,7 +24,7 @@ class Plans extends AbstractApi
      */
     public function createPlan(CreatePlanRequest $request)
     {
-        return $this->client->request('POST', 'plans', self::PLAN_RESPONSE_CLASS, $request);
+        return $this->client->post('plans', self::PLAN_RESPONSE_CLASS, $request);
     }
 
     /**
@@ -34,7 +34,7 @@ class Plans extends AbstractApi
      */
     public function getPlan($planId)
     {
-        return $this->client->request('GET', 'plans/' . $planId, self::PLAN_RESPONSE_CLASS);
+        return $this->client->get('plans/' . $planId, self::PLAN_RESPONSE_CLASS);
     }
 
     /**
@@ -53,7 +53,7 @@ class Plans extends AbstractApi
         if (!is_null($metadata)) {
             $data['metadata'] = $metadata;
         }
-        return $this->client->request('POST', 'plans/' . $planId, self::PLAN_RESPONSE_CLASS, $data);
+        return $this->client->post('plans/' . $planId, self::PLAN_RESPONSE_CLASS, $data);
     }
 
     /**
@@ -63,7 +63,7 @@ class Plans extends AbstractApi
      */
     public function deletePlan($planId)
     {
-        return $this->client->request('DELETE', 'plans/' . $planId, self::DELETE_RESPONSE_CLASS);
+        return $this->client->delete('plans/' . $planId, self::DELETE_RESPONSE_CLASS);
     }
 
     /**
@@ -74,7 +74,7 @@ class Plans extends AbstractApi
      */
     public function listPlans($count = 10, $offset = 0)
     {
-        return $this->client->request('GET', 'plans', 'Stripe\Response\Plans\ListPlansResponse', null, array('count' => $count, 'offset' => $offset));
+        return $this->client->get('plans', 'Stripe\Response\Plans\ListPlansResponse', null, array('count' => $count, 'offset' => $offset));
     }
 
     /**
@@ -89,4 +89,4 @@ class Plans extends AbstractApi
     {
         return new CreatePlanRequest($id, $amount, $currency, $interval, $name);
     }
-} 
+}

--- a/src/Stripe/Api/Subscriptions.php
+++ b/src/Stripe/Api/Subscriptions.php
@@ -25,7 +25,7 @@ class Subscriptions extends AbstractApi
      */
     public function createSubscription($customerId, CreateSubscriptionRequest $request)
     {
-        return $this->client->request('POST', $this->buildUrl($customerId), self::SUBSCRIPTION_RESPONSE_CLASS, $request);
+        return $this->client->post($this->buildUrl($customerId), self::SUBSCRIPTION_RESPONSE_CLASS, $request);
     }
 
     /**
@@ -36,7 +36,7 @@ class Subscriptions extends AbstractApi
      */
     public function getSubscription($customerId, $subscriptionId)
     {
-        return $this->client->request('GET', $this->buildUrl($customerId, $subscriptionId), self::SUBSCRIPTION_RESPONSE_CLASS);
+        return $this->client->get($this->buildUrl($customerId, $subscriptionId), self::SUBSCRIPTION_RESPONSE_CLASS);
     }
 
     /**
@@ -48,7 +48,7 @@ class Subscriptions extends AbstractApi
      */
     public function updateSubscription($customerId, $subscriptionId, UpdateSubscriptionRequest $request)
     {
-        return $this->client->request('POST', $this->buildUrl($customerId, $subscriptionId), self::SUBSCRIPTION_RESPONSE_CLASS, $request);
+        return $this->client->post($this->buildUrl($customerId, $subscriptionId), self::SUBSCRIPTION_RESPONSE_CLASS, $request);
     }
 
     /**
@@ -60,7 +60,7 @@ class Subscriptions extends AbstractApi
      */
     public function cancelSubscription($customerId, $subscriptionId, $atPeriodEnd = false)
     {
-        return $this->client->request('DELETE', $this->buildUrl($customerId, $subscriptionId), self::SUBSCRIPTION_RESPONSE_CLASS, null, array('at_period_end' => $atPeriodEnd));
+        return $this->client->delete($this->buildUrl($customerId, $subscriptionId), self::SUBSCRIPTION_RESPONSE_CLASS, null, array('at_period_end' => $atPeriodEnd));
     }
 
     /**
@@ -72,7 +72,7 @@ class Subscriptions extends AbstractApi
      */
     public function listSubscriptions($customerId, $count = 10, $offset = 0)
     {
-        return $this->client->request('GET', $this->buildUrl($customerId), 'Stripe\Response\Subscriptions\ListSubscriptionsResponse', null, array('count' => $count, 'offset' => $offset));
+        return $this->client->get($this->buildUrl($customerId), 'Stripe\Response\Subscriptions\ListSubscriptionsResponse', null, array('count' => $count, 'offset' => $offset));
     }
 
     /**
@@ -105,4 +105,4 @@ class Subscriptions extends AbstractApi
         }
         return $url;
     }
-} 
+}

--- a/src/Stripe/Stripe.php
+++ b/src/Stripe/Stripe.php
@@ -22,7 +22,7 @@ use Stripe\Api\Tokens;
 /**
  * Class Stripe
  *
- * @property Api\Accounts
+ * @property Api\Accounts $accounts
  * @property Api\Cards $cards
  * @property Api\Charges $charges
  * @property Api\Customers $customers


### PR DESCRIPTION
In some places we were using `client->request('GET'...` and in others we were using `client->get(...`. This standardizes it across the Api classes.
