### PR TITLE
Travis CI Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ php:
   - 5.6
   - hhvm
 
-env:
-  - API_KEY=tGN0bIwXnHdwOa85VABjPdSn8nWY7G7I
-
 before_script:
   - composer self-update
   - composer update --dev

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,7 +15,8 @@
 
     <php>
         <!-- copy this file to phpunit.xml and replace enter your test key to run tests -->
-        <server name="API_KEY" value="your_test_key" />
+        <!-- This is currently using the Stripe Test API Key -->
+        <server name="API_KEY" value="tGN0bIwXnHdwOa85VABjPdSn8nWY7G7I" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
This PR creates a travis config file for testing on multiple versions of PHP (and HHVM) using http://travis-ci.org

I put the Stripe Test API key (the same one they use in their testing config) into the phpunit.xml.dist as well. I figured that one was safe to use.

On a side note, it seems the tests are failing due to an error with counting from an `AbstractListResponse`. The PR should be good to merge, but we need to fix the tests.

Once merged, you can login to travis using your github account, and then enable the CI testing.
