### PR TITLE
Enabled Transfers, Loaded Doctrine annotations in CLI mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,15 @@
 {
-    "name": "urakozz/stripe-api-php",
+    "name": "jlinn/stripe-api-php",
     "type": "library",
+    "description": "A PHP client library for Stripe's REST API",
+    "keywords": ["stripe", "api", "payments"],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Joe Linn",
+            "homepage": "https://github.com/jlinn"
+        }
+    ],
     "require": {
         "php": ">=5.3.2",
         "guzzle/guzzle": "~3.8",


### PR DESCRIPTION
Enabled Transfers (and tested)
Loadrd Doctrine annotations in CLI mode (using in cli mode was impossible due to absent doctrine autoloader)
